### PR TITLE
Fix ENV name for ruboty.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ gem 'ruboty-local_yaml'
 
 ## ENV
 ```
-LOCAL_YAML_FILE_PATH # Yaml path (default: ruboty.yml)
+LOCAL_YAML_PATH      # Yaml path (default: ruboty.yml)
 LOCAL_YAML_INTERVAL  # Interval time to write (default: 5)
 ```
 


### PR DESCRIPTION
It seems LOCAL_YAML_PATH is the correct name https://github.com/rutan/ruboty-local_yaml/blob/d9cca98b4e8366a90f4cb65b5572c7ca7a9b6a54/lib/ruboty/brains/local_yaml.rb#L45